### PR TITLE
Fix the missing sw-context-token issue

### DIFF
--- a/src/Resources/fastly_config/deliver.vcl
+++ b/src/Resources/fastly_config/deliver.vcl
@@ -2,10 +2,9 @@
 unset resp.http.x-powered-by;
 
 # Cache Store-API requests
-if (req.http.swhit == "1" || req.method == "GET") {
+if (fastly_info.state ~ "HIT" || (req.method == "GET" && req.http.store-api-post == "1")) {
   unset resp.http.Sw-Context-Token;
   unset resp.http.sw-context-token;
-  unset resp.http.swhit;
 }
 
 # We use fastly.ff.visits_this_service to avoid running this logic on shield nodes. We only need to

--- a/src/Resources/fastly_config/hit.vcl
+++ b/src/Resources/fastly_config/hit.vcl
@@ -1,5 +1,3 @@
-set req.http.swhit = "1";
-
 if (req.http.cookie:sw-states) {
    set req.http.states = req.http.cookie:sw-states;
 


### PR DESCRIPTION
This issue was previously addressed for one of our first customers, but we forgot to create a PR.
Today we had the same problem for a new customer. Applying this fix solves the issue.

The problem is the first call to `/store-api/context` is a GET.
This call is supposed to send back a `sw-context-token` header which will be used for the subsequent requests.

So the fix limits the deletion of the `sw-context-token` header to the GET requests that were POST before.