### PR TITLE
Fix Fastly 414 errors by preventing oversized Store API cache URLs

### DIFF
--- a/src/Resources/fastly_config/recv.vcl
+++ b/src/Resources/fastly_config/recv.vcl
@@ -62,10 +62,17 @@ if (req.url.path ~ "^/(checkout|account|admin|api|csrf)(/.*)?$") {
 
 # Cache Store-API requests
 if (req.url.path ~ "^/store-api/.*?$" && req.url.path !~ "^/store-api/account/.*$" && req.method == "POST") {
-  set req.http.store-api-post = "1";
-  set req.method = "GET";
   if (req.body) {
-    set req.url = querystring.set(req.url, "j", urlencode(req.body));
+    if (std.strlen(req.body) < 3500) {
+      set req.http.store-api-post = "1";
+      set req.method = "GET";
+      
+      set req.url = querystring.set(req.url, "j", urlencode(req.body));
+    }
+  }
+  else {
+      set req.http.store-api-post = "1";
+      set req.method = "GET";
   }
 }
 


### PR DESCRIPTION
### Context

We observed **Fastly 414 URI Too Long errors** on cacheable Shopware Store API requests when using the existing POST-to-GET workaround that serializes the full JSON body into the j query parameter.

Large criteria payloads (deep associations / includes) easily exceed Fastly’s hard 8KB URL limit when URL-encoded, causing requests to fail at the CDN layer.

### Root cause

The current Fastly workaround:
- 	rewrites `POST /store-api/**` to `GET`
- 	appends the full request body as `?j=<urlencoded JSON>`

This approach:
- 	works only for small payloads
- 	breaks deterministically once the JSON exceeds Fastly’s URL length limit
- 	explains why minified payloads succeed while formatted payloads fail

### What this PR changes

This PR adjusts the caching logic to **avoid generating oversized URLs** while preserving correctness:
- 	Keeps the existing Shopware Store API caching behavior intact
- 	Prevents requests with large bodies from being rewritten into cacheable GET requests
- 	Avoids encoding large POST bodies into query parameters
- 	Eliminates Fastly 414 errors without breaking Store API semantics

Large Store API POST requests will now bypass edge caching instead of failing, while smaller requests remain cacheable.

### Why this approach

- 	Fastly has a non-configurable URL size limit
- 	The Shopware Store API cache plugin relies on the j parameter containing valid JSON
- 	Hashing or compressing j would break backend request reconstruction
- 	This change favors correctness and stability over aggressive caching

### Result

- 	No more Fastly 414 errors
- 	Store API requests remain functional regardless of payload size
- 	Caching is applied only where it is safe and supported